### PR TITLE
add browser extension to inject javascript #12

### DIFF
--- a/privacy-analysis-tool/extension/src/background.js
+++ b/privacy-analysis-tool/extension/src/background.js
@@ -1,0 +1,7 @@
+browser.browserAction.onClicked.addListener(function (activeTab) {
+  browser.tabs.create({ url: browser.runtime.getURL("dashboard/index.html") });
+});
+
+browser.runtime.onInstalled.addListener(function (object) {
+  //browser.tabs.update({ url: browser.runtime.getURL("dashboard/index.html") });
+});

--- a/privacy-analysis-tool/extension/src/content.js
+++ b/privacy-analysis-tool/extension/src/content.js
@@ -1,0 +1,13 @@
+document.addEventListener("DOMContentLoaded", function () {
+  /*
+    const iframe = document.createElement('iframe');
+    document.documentElement.appendChild(iframe);
+    iframe.contentDocument.body.innerHTML = `
+    <div id="modal">TEST TEdsdfST TESTddd</div>
+    `;*/
+  const div = document.createElement("div");
+  div.innerHTML = `
+<div id="modal"><strong style="font-weight: 800;"></strong><img src="https://www.privacytechlab.org/static/images/plt_logo.png"></div>
+`;
+  document.body.appendChild(div);
+});

--- a/privacy-analysis-tool/extension/src/dashboard/index.html
+++ b/privacy-analysis-tool/extension/src/dashboard/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Integrated Privacy Analysis</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet" />
+    <script type="text/javascript" src="./js/script.js"></script>
+  </head>
+  <body class="p-32 bg-gray-100">
+    <div class="grid grid-rows-32">
+      <h1 class="place-self-center p-8 text-4xl font-light">Integrated Privacy Analysis</h1>
+      <div class="place-self-center ">
+        <input class="p-2.5 px-4 text-base rounded-lg shadow-lg border border-transparent focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent " style="width: 36rem" type="text" placeholder="Enter website to begin analysis" id="input" />
+        <button class="mx-4 bg-gray-600 hover:bg-blue-600 focus:outline-none p-2.5 px-4 text-base rounded-lg shadow-lg text-white" id="btn">
+          Begin
+        </button>
+      </div>
+  </body>
+</html>

--- a/privacy-analysis-tool/extension/src/dashboard/js/script.js
+++ b/privacy-analysis-tool/extension/src/dashboard/js/script.js
@@ -1,0 +1,6 @@
+document.addEventListener("DOMContentLoaded", function () {
+  document.getElementById("btn").addEventListener("click", () => {
+    const url = document.getElementById("input").value;
+    chrome.tabs.update({ url: url });
+  });
+});

--- a/privacy-analysis-tool/extension/src/manifest.json
+++ b/privacy-analysis-tool/extension/src/manifest.json
@@ -1,0 +1,25 @@
+{
+  "name": "Integrated Privacy Analysis",
+  "version": "0.0.2",
+  "browser_action": {
+    "default_title": "Dashboard"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "css": ["styles.css"],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "applications": {
+    "gecko": {
+      "id": "integrated-privacy-analysis@privacytechlab.org",
+      "strict_min_version": "52.0"
+    }
+  },
+  "manifest_version": 2
+}

--- a/privacy-analysis-tool/extension/src/styles.css
+++ b/privacy-analysis-tool/extension/src/styles.css
@@ -1,0 +1,17 @@
+#modal {
+  z-index: 999;
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+
+  width: 200px;
+  height: 300px;
+
+  padding: 16px;
+
+  border-radius: 0.5rem;
+
+  box-shadow: 0px 0px 64px 8px rgba(0,0,0,0.2);
+
+  background-color: white;
+}

--- a/privacy-analysis-tool/proxy_server.py
+++ b/privacy-analysis-tool/proxy_server.py
@@ -4,6 +4,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import NoSuchWindowException
 from selenium.common.exceptions import WebDriverException
+from pathlib import Path
 import time
 import json
 from json.decoder import JSONDecodeError
@@ -92,6 +93,10 @@ def setUpSelenium():
     profile.set_proxy(proxy.selenium_proxy())
     driver = webdriver.Firefox(firefox_profile=profile)
 
+    # attach extension to interface with user
+    extension_dir = getFilePath('extension/dist/extension.xpi')
+    driver.install_addon(str(Path(extension_dir).absolute()))
+
     return (proxy, driver, server)
 
 # function to get the proxy info and put all POST requests into our saved file
@@ -144,9 +149,9 @@ def setUpNetworkMonitoring(proxy, driver, site, counter, requests):
     return requests
 
 def main():
-"""
-This is the main function where all of the main calls are made.
-"""
+    """
+    This is the main function where all of the main calls are made.
+    """
     # this is a placeholder for some sort of GUI when we create the app
     site = input("What's the name of the site you are visiting? ")
     # first we're gonna make our json file of network calls to analyze and make sure


### PR DESCRIPTION
Selenium offers a few ways to inject javascript. Using a browser extension provides the most flexibility, so the extension will be installed once the browser launches and it will sit in the background injecting javascript that will guide the user. I've only scaffolded this out, including the modal that I had before in the chrome extension. The next step will be to see and build the experience through.

Currently, we are using firefox with selenium. In order to get the extension installed to firefox via selenium, I had to submit the extension for review with Mozilla. Though, the review process took only a few minutes.