### PR TITLE
Issue 144

### DIFF
--- a/src/background/analysis/searchFunctions.js
+++ b/src/background/analysis/searchFunctions.js
@@ -251,7 +251,6 @@ function coordinateSearch(strReq, locData, rootUrl, reqUrl) {
   }
 
   if (foundLat && foundLng) {
-    console.log(strReq.slice(start, end))
     addToEvidenceList(permissionEnum.location, rootUrl, strReq, reqUrl, typeEnum.coarseLocation, [start, end])
   }
 }


### PR DESCRIPTION
Re-wrote the coordinate search. Requires a lat and lng in the same request to flag. Switch to regex improves analysis time. With some light browsing, it's pointing out netflix and youtube. It's not working with google maps which is odd, but definitely an improvement from the old function.