### PR TITLE
#237 fix bug with undefined rootUrl, add some documentation.

### DIFF
--- a/src/background/analysis/interactDB/addEvidence.js
+++ b/src/background/analysis/interactDB/addEvidence.js
@@ -23,8 +23,18 @@ import { Evidence, typeEnum, storeEnum } from "../classModels.js"
 // perm, rootU, snip, requestU, t, i, extraDetail = undefined)
 async function addToEvidenceStore(evidenceToAdd, firstParty, parent, rootU, requestU) {
 
-  const ts = Date.now()
+  /**
+   * This is a known bug where certain websites intiate requests where the rootURL 
+   * is undefined. rootURL comes from request.details["originUrl"] which is a property 
+   * of the onBeforeRequest callback:
+   * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest#details
+   * In this case, we do not add evidence and return.
+   */
+  if (rootU == undefined) { return new Promise( function(resolve, reject) {
+    resolve('undefined rootU');
+  }) }; 
 
+  const ts = Date.now()
   const rootUrl = getHostname(rootU)
   const store = firstParty ? storeEnum.firstParty : storeEnum.thirdParty
 
@@ -39,11 +49,13 @@ async function addToEvidenceStore(evidenceToAdd, firstParty, parent, rootU, requ
       extraDetail = undefined
     }
     else { [perm, rootU, snip, requestU, t, i, extraDetail] = evidenceListObject}
-  
+
     rootU = rootUrl
   
     // whitelist our IP API
-    if (requestU == 'http://ip-api.com/json/'){return;}
+    if (requestU == 'http://ip-api.com/json/'){ return new Promise( function(resolve, reject) {
+      resolve('whitelist IP API');
+    }) };
   
     const e = new Evidence( {
       timestamp: ts,
@@ -61,9 +73,11 @@ async function addToEvidenceStore(evidenceToAdd, firstParty, parent, rootU, requ
     evidence = updateFetchedDict(evidence, e)
   }
 
+  // update the fetched evidence dict with each piece of evidence we have for this request
   for ( const evidenceList of evidenceToAdd) {
     unpackAndUpdate(evidenceList)
     }
+
   //final return statement
   return new Promise( function(resolve, reject) {
     evidenceKeyval.set(rootUrl, evidence, store)
@@ -72,15 +86,23 @@ async function addToEvidenceStore(evidenceToAdd, firstParty, parent, rootU, requ
 }
 
 
+/**
+ * Function used to update an already fetched evidence dictionary with a piece of evidence, e.
+ * 
+ * @param {Dict} evidenceDict The dictionary we are updating 
+ * @param {Evidence} e An evidence object
+ * @returns {Dict} The param evidenceDict, but updated with Evidence, e, appropriately
+ */
 function updateFetchedDict(evidenceDict, e) {
-  /**
-      * Used to push evidence through (override evidence cap of 4 per type)
-      * that will create multiple labels for one request URL
-      *
-      * @param {Object} currDict object with the dexisting evidence for a permission
-      * @param {string} typ the type that we're currently trying to add
-      * @returns {Set} The urls that already have evidence within this permission
-      */
+    
+    /**
+    * Used to push evidence through (override evidence cap of 4 per type)
+    * that will create multiple labels for one request URL
+    *
+    * @param {Object} currDict object with the dexisting evidence for a permission
+    * @param {string} typ the type that we're currently trying to add
+    * @returns {Set} The urls that already have evidence within this permission
+    */
    function getReqUrlsWithDifferentTypes(currDict, typ) {
 
     var reqUrlSet = new Set()

--- a/src/background/analysis/utility/util.js
+++ b/src/background/analysis/utility/util.js
@@ -23,7 +23,7 @@ function hashTypeAndPermission(str) {
 /**
  * Returns only the hostnames from a url. code from https://stackoverflow.com/questions/8498592/extract-hostname-name-from-string
  * @param {string} url 
- * @returns {string} The hostname of the given URL.
+ * @returns {string} The hostname of the given URL. '' if URL undefined
  */
 function extractHostname(url) {
 
@@ -49,8 +49,9 @@ function extractHostname(url) {
 
 /**
  * Takes a url and returns its domain.
+ * https://stackoverflow.com/questions/8498592/extract-hostname-name-from-string
  * @param {string} url 
- * @returns {string} The domain of a the inputted url https://stackoverflow.com/questions/8498592/extract-hostname-name-from-string
+ * @returns {string} The domain of a the inputted url, '' if input undefined
  */
 function getHostname(url) {
   if (typeof url == 'undefined') return ''


### PR DESCRIPTION
Fixes the bug described in #237. I added some documentation in the code describing what's going on. We use the `originUrl` property of this [callback](https://developer.mozilla.org/en-US/docs/Mozilla/Addons/WebExtensions/API/webRequest/onBeforeRequest#details) to define the URL that initiated a request. In rare cases (I would estimate at least < .25% but probably lower), this property is undefined.

So, in this PR, we correctly ignore these requests. This is what we had done previously. The website [reddit](https://reddit.com) recreates the bug.

I looked a little more specifically into what was going on in this instance and found that the `undefined` `originUrl` also has an `undefined` `documentUrl` a`null` `requestBody` and empty `frameAncestors`. The request URL is `reddit.com` and it gets flagged as `tracking_social` by firefox (this is why it is attempting to be added to evidence).

Screenshot below:

![Screen Shot 2021-07-16 at 1 09 37 PM](https://user-images.githubusercontent.com/51685858/125984762-4ed6a2c7-8574-413c-8711-ba3fd19a7a5e.png)

close #237 on merge.
 