### PR TITLE
Cut Down Request Object, Abandon Requests While Filtering

### DIFF
--- a/src/background/analysis/classModels.js
+++ b/src/background/analysis/classModels.js
@@ -28,9 +28,8 @@ the codebase.
 export class Request {
   constructor({
     id,
-    details,
-    requestHeaders,
-    responseHeaders,
+    rootUrl,
+    reqUrl,
     requestBody,
     responseData,
     error,
@@ -38,11 +37,10 @@ export class Request {
     urlClassification,
   }) {
     this.id = id
-    this.requestHeaders = requestHeaders
-    this.responseHeaders = responseHeaders
-    this.responseData = responseData
+    this.rootUrl = rootUrl
+    this.reqUrl = reqUrl
     this.requestBody = requestBody
-    this.details = details
+    this.responseData = responseData
     this.error = error
     this.type = type
     this.urlClassification = urlClassification

--- a/src/background/analysis/constants.js
+++ b/src/background/analysis/constants.js
@@ -1,0 +1,1 @@
+export const MAX_BYTE_LEN = 200000

--- a/src/background/analysis/constants.js
+++ b/src/background/analysis/constants.js
@@ -1,1 +1,11 @@
+/**
+ * Used in request filter. Javascript uses 2 bytes per char, so 200k byte cap lines up with
+ * 100k char cap
+ */
 export const MAX_BYTE_LEN = 200000
+
+/**
+ * Used by heuristic funciton to choose when to analyze
+ * Based on an analysis that the most labels come from shorter requests
+ */
+export const MAX_CHAR_LEN = 100000

--- a/src/background/analysis/requestAnalysis/earlyTermination/heuristics.js
+++ b/src/background/analysis/requestAnalysis/earlyTermination/heuristics.js
@@ -1,3 +1,5 @@
+import { MAX_CHAR_LEN } from "../../constants.js"
+
 /**
  * 100000 choice based on analysis here: https://github.com/privacy-tech-lab/privacy-pioneer/issues/297
  * To maximize performance while keeping complexity to a reasonable level.
@@ -8,7 +10,7 @@
  */
 function lengthHeuristic(strReq) {
     const requestLen = strReq.length
-    return requestLen > 100000
+    return requestLen > MAX_CHAR_LEN
 }
 
 export { lengthHeuristic }

--- a/src/background/analysis/requestAnalysis/scanHTTP.js
+++ b/src/background/analysis/requestAnalysis/scanHTTP.js
@@ -83,8 +83,6 @@ function getAllEvidenceForRequest(request, userData) {
   runWatchlistAnalysis()
   runStandardAnalysis()
 
-  console.log(evidenceArr)
-
   return evidenceArr
 
   /**

--- a/src/background/analysis/requestAnalysis/scanHTTP.js
+++ b/src/background/analysis/requestAnalysis/scanHTTP.js
@@ -35,6 +35,7 @@ function getAllEvidenceForRequest(request, userData) {
 
   const optimizePerformance = userData[4]
 
+  // We only perform our analysis on reqUrl, requestBody, and responseData.
   const strRequest = JSON.stringify(request, 
       ["reqUrl",
       "requestBody",

--- a/src/background/analysis/requestAnalysis/scanHTTP.js
+++ b/src/background/analysis/requestAnalysis/scanHTTP.js
@@ -22,8 +22,8 @@ import { lengthHeuristic } from "../requestAnalysis/earlyTermination/heuristics.
  */
 function getAllEvidenceForRequest(request, userData) {
 
-  const rootUrl = request.details["originUrl"]
-  const reqUrl = request.details["url"]
+  const rootUrl = request.rootUrl
+  const reqUrl = request.reqUrl
 
   // this 0, 1, 2 comes from the structure of the importData function
   // location we obtained from google maps API
@@ -35,9 +35,14 @@ function getAllEvidenceForRequest(request, userData) {
 
   const optimizePerformance = userData[4]
 
-  const strRequest = JSON.stringify(request);
+  const strRequest = JSON.stringify(request, 
+      ["reqUrl",
+      "requestBody",
+      "responseData"]
+    );
 
-  var evidenceArr = [];
+  var evidenceArr = []
+
 
   // we don't surface these evidences, so skip.
   if (typeof rootUrl == "undefined") {
@@ -62,10 +67,7 @@ function getAllEvidenceForRequest(request, userData) {
     }
   }
 
-  
-  // always search to see if the url of the root or request comes up in our services list
-  // comment out below line when testing termination heuristics
-  executeAndPush(urlSearch(strRequest, rootUrl, reqUrl, request.urlClassification))
+  executeAndPush(urlSearch(rootUrl, reqUrl, request.urlClassification))
 
 
   function earlyTermination() {
@@ -80,6 +82,8 @@ function getAllEvidenceForRequest(request, userData) {
 
   runWatchlistAnalysis()
   runStandardAnalysis()
+
+  console.log(evidenceArr)
 
   return evidenceArr
 

--- a/src/background/analysis/requestAnalysis/searchFunctions.js
+++ b/src/background/analysis/requestAnalysis/searchFunctions.js
@@ -117,7 +117,7 @@ function urlSearch(rootUrl, reqUrl, classifications) {
    * @returns {void} Nothing. Adds to evidence list
    */
   function addDisconnectEvidence(perm, type) {
-    output.push(createEvidenceObj(perm, request.details["originUrl"], "null", request.details["url"], type, undefined))
+    output.push(createEvidenceObj(perm, request.rootUrl, "null", request.reqUrl, type, undefined))
   }
   
   // The fingerprintingInvasive category is the only one we are traversing.

--- a/src/background/analysis/requestAnalysis/searchFunctions.js
+++ b/src/background/analysis/requestAnalysis/searchFunctions.js
@@ -71,7 +71,7 @@ const classificationTransformation = {
  * @param {object} urls The disconnect JSON
  * @returns {Array<Array>|Array} An array of arrays with the search results [] if no result 
  */
-function urlSearch(strReq, rootUrl, reqUrl, classifications) {
+function urlSearch(rootUrl, reqUrl, classifications) {
   var output = []
   let firstPartyArr = classifications.firstParty;
   let thirdPartyArr = classifications.thirdParty;
@@ -81,7 +81,7 @@ function urlSearch(strReq, rootUrl, reqUrl, classifications) {
       if (classification in classificationTransformation) {
         let p, t;
         [p, t] = classificationTransformation[classification];
-        output.push(createEvidenceObj(p, rootUrl, strReq, reqUrl, t, undefined))
+        output.push(createEvidenceObj(p, rootUrl, null, reqUrl, t, undefined))
       }
     }
   }
@@ -129,7 +129,7 @@ function urlSearch(strReq, rootUrl, reqUrl, classifications) {
     var nextKey = Object.keys(urls["categories"][cat][j][indivKey])
     for (var k = 0; k < nextKey.length; k++) {
       var urlLst = urls["categories"][cat][j][indivKey][nextKey[k]]
-      var url = request.details["url"]
+      var url = request.reqUrl
       // if there are multiple URLs on the list we go here
       for (var u = 0; u < urlLst.length; u++) {
         if (url.includes(urlLst[u])) {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -11,11 +11,7 @@ background.js
 - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest
 */
 
-import {
-  onBeforeRequest,
-  onBeforeSendHeaders,
-  onHeadersReceived,
-} from "./analysis/analyze.js"
+import { onBeforeRequest } from "./analysis/analyze.js"
 import { setDefaultSettings } from "../libs/settings/index.js"
 import { importData } from "./analysis/buildUserData/importSearchData.js"
 import Queue from "queue"
@@ -41,6 +37,7 @@ export var evidenceQ = Queue({ results: [], concurrency: 1, autostart: true })
 // Get url of active tab for popup
 browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.msg == "background.currentTab") {
+
     // send current, open tab to the runtime (our extension)
     const send = (tabs) =>
       browser.runtime.sendMessage({
@@ -79,41 +76,7 @@ importData().then((data) => {
     filter,
     ["requestBody", "blocking"]
   )
-
-  // Listener to get request headers
-  // Note: I'm not sure if there is a difference between the details of a request here and onBeforeRequest
-  // maybe timestamp difference, antyhing else important?
-  browser.webRequest.onBeforeSendHeaders.addListener(
-    function (details) {
-      onBeforeSendHeaders(details, data)
-    },
-    filter,
-    ["requestHeaders"]
-  )
-
-  // Listener to get response headers
-  // Note: I'm not sure if there is a difference between the details of a request here and onBeforeRequest
-  // maybe timestamp differece, antyhing else important?
-  browser.webRequest.onResponseStarted.addListener(
-    function (details) {
-      onHeadersReceived(details, data)
-    },
-    filter,
-    ["responseHeaders"]
-  )
 })
-
-async function initDB(initArr) {
-  for (let initItem of initArr) {
-    let key, keyword, type, id;
-    [key, keyword, type, id] = initItem
-    watchlistKeyval.set(key, {
-      keyword: keyword,
-      type: type,
-      id: id,
-    })
-  }
-}
 
 setDefaultSettings()
 
@@ -123,7 +86,7 @@ setDefaultSettings()
  * Revokes the object URL after a download has been successfully completed or interrupted.
  * downloadDelta: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/downloads/onChanged#downloaddelta
  */
-browser.downloads.onChanged.addListener(async function (downloadDelta) {
+browser.downloads.onChanged.addListener( async function (downloadDelta) {
   const status = downloadDelta.state.current
   // if the download is finished, we fetch the url for the download and revoke that object URL
   if (status === "complete" || status === "interrupted") {
@@ -138,3 +101,4 @@ browser.downloads.onChanged.addListener(async function (downloadDelta) {
     }
   }
 })
+


### PR DESCRIPTION
## In this PR:

1) Cuts down on the traits of HTTP requests that we look at (notably, removes request/response headers)
2) Stops decoding HTTP responses that exceed the max char length of 100k (checks for 200k byte length) before passing them on to be analyzed
3) Only performs analysis on `reqUrl`, `requestBody`, and `responseBody`

## Note: 
There may be a reduction in labels after merge. Notably, labels created from cookies set via headers as described in #314. However, the performance improvement will also be significant.

Close #314 on merge.
Close #312 on merge.