### PR TITLE
Issue 313 v2

### DIFF
--- a/src/background/analysis/analyze.js
+++ b/src/background/analysis/analyze.js
@@ -74,18 +74,20 @@ const onBeforeRequest = async (details, data) => {
       urlClassification: details.urlClassification !== undefined ? details.urlClassification : [],
     })
     
-    buffer[details.requestId] = request
 
     if (details.tabId == -1) {
       request.rootUrl = details.originUrl
+      buffer[details.requestId] = request
     }
     else {
       try {
         const rootUrlObj = await browser.tabs.get(details.tabId)
         request.rootUrl = rootUrlObj.url 
+        buffer[details.requestId] = request
       }
       catch (err) {
         request.rootUrl = details.originUrl
+        buffer[details.requestId] = request
       }
     }
   }

--- a/src/background/analysis/classModels.js
+++ b/src/background/analysis/classModels.js
@@ -70,7 +70,6 @@ export const resourceTypeEnum = Object.freeze({
  * @property {string} requestUrl The request Url as a string
  * @property {enum} typ The type of the evdience
  * @property {Array|undefined} index A length 2 array with the indexes of the evidence or undefined if not applicable
- * @property {boolean} firstPartyRoot A boolean indicating if the evidence was generated with a first party root (the rootUrl of the request is the same as the website that generated the request)
  * @property {string|null} parentCompany If we have identified a parent company for this url, we store it here for the frontend. Else, null.
  * @property {string|undefined} watchlistHash If the evidence is from our watchlist, this is the id of that item. Used for deletion of evidence on deletion of watchlist item
  * @property {string|undefined} extraDetail Extra details as needed. Currently only used for encoded email's original email
@@ -84,7 +83,6 @@ export class Evidence {
     requestUrl,
     typ,
     index,
-    firstPartyRoot,
     parentCompany,
     watchlistHash,
     extraDetail,
@@ -96,7 +94,6 @@ export class Evidence {
     this.requestUrl = requestUrl
     this.typ = typ
     this.index = index === undefined ? -1 : index
-    this.firstPartyRoot = firstPartyRoot
     this.parentCompany = parentCompany
     this.watchlistHash = watchlistHash
     this.extraDetail = extraDetail
@@ -115,13 +112,6 @@ export class KeywordObject {
   }
 }
 
-/**
- * @enum {string} Enum used to reference which evidenceKeyval object store you want
- */
-export const storeEnum = Object.freeze({
-  firstParty: "firstPartyEvidence",
-  thirdParty: "thirdPartyEvidence",
-})
 
 /**
  * @enum {string} Enum used to reference file formats that are available for export

--- a/src/background/analysis/interactDB/addEvidence.js
+++ b/src/background/analysis/interactDB/addEvidence.js
@@ -5,7 +5,7 @@ privacy-tech-lab, https://www.privacytechlab.org/
 
 import { getHostname } from "../utility/util.js"
 import { evidenceKeyval } from "../interactDB/openDB.js"
-import { Evidence, typeEnum, storeEnum } from "../classModels.js"
+import { Evidence } from "../classModels.js"
 import { settingsKeyval } from "../../../libs/indexed-db/openDB.js";
 
 
@@ -21,7 +21,6 @@ import { settingsKeyval } from "../../../libs/indexed-db/openDB.js";
  * Used in analyze.js
  * 
  * @param {Object} evidenceToAdd Evidence that the function should add to the correct store in evidenceIDB
- * @param {boolean} firstParty Whether the evidence is a first party request
  * @param {string|undefined} parent Parent company of the request Url, if possible
  * @param {string} rootU The rootUrl of the request
  * @param {string} requestU The requestUrl of the request
@@ -30,7 +29,7 @@ import { settingsKeyval } from "../../../libs/indexed-db/openDB.js";
  */
 
 // perm, rootU, snip, requestU, t, i, extraDetail = undefined)
-async function addToEvidenceStore(evidenceToAdd, firstParty, parent, rootU, requestU, saveFullSnippet) {
+async function addToEvidenceStore(evidenceToAdd, parent, rootU, requestU, saveFullSnippet) {
 
   /**
    * This is a known bug where certain websites intiate requests where the rootURL 
@@ -45,9 +44,8 @@ async function addToEvidenceStore(evidenceToAdd, firstParty, parent, rootU, requ
 
   const ts = Date.now()
   const rootUrl = getHostname(rootU)
-  const store = firstParty ? storeEnum.firstParty : storeEnum.thirdParty
 
-  var evidence = await evidenceKeyval.get(rootUrl, store)
+  var evidence = await evidenceKeyval.get(rootUrl)
   if (evidence === undefined) { evidence = {} }
 
   /**
@@ -62,7 +60,6 @@ async function addToEvidenceStore(evidenceToAdd, firstParty, parent, rootU, requ
     // if this is a valid object
     if (evidenceObject.rootUrl){
       evidenceObject.timestamp = ts
-      evidenceObject.firstPartyRoot = firstParty
       evidenceObject.rootUrl = rootU
       evidenceObject.parentCompany = parent
 
@@ -118,7 +115,7 @@ async function addToEvidenceStore(evidenceToAdd, firstParty, parent, rootU, requ
 
   //final return statement
   return new Promise( function(resolve, reject) {
-    evidenceKeyval.set(rootUrl, evidence, store)
+    evidenceKeyval.set(rootUrl, evidence)
     resolve('set');
   });
 }

--- a/src/background/analysis/interactDB/openDB.js
+++ b/src/background/analysis/interactDB/openDB.js
@@ -11,14 +11,15 @@ requestModel.js
 
 import { openDB } from "idb";
 
+const storeKey = "firstPartyEvidence"
+
 /**
  * @type {Promise}
  * opens up the DB. Used by the evidenceKeyval constant to mutate the DB.
  */
-const dbPromise = openDB("keyval-store", 2, {
+const dbPromise = openDB("keyval-store", 1, {
   upgrade(db) {
-    db.createObjectStore("firstPartyEvidence");
-    db.createObjectStore("thirdPartyEvidence");
+    db.createObjectStore(storeKey);
   },
 });
 
@@ -31,27 +32,27 @@ const dbPromise = openDB("keyval-store", 2, {
  * Used in backend (classModels.js, addEvidence.js, createBlob.js) and frontend (libs/indexed-db/index.js)
  * 
  * @class idbKeyval
- * @method get param(key, store) returns a promise with the value at a given key. undefined if no such key exists.
- * @method set param(key, val, store) sets a value at a key
- * @method del param(key, store) deletes a key value pair
- * @method clear param(store) empties the given object store
- * @method keys param(store) returns all the keys in the given object store
- * @method values param(store) returns all the all vaues in the given object store
+ * @method get param(key) returns a promise with the value at a given key. undefined if no such key exists.
+ * @method set param(key, val) sets a value at a key
+ * @method del param(key) deletes a key value pair
+ * @method clear param() empties the evidence store
+ * @method keys param() returns all the keys in the evidence store
+ * @method values param() returns all the all vaues in the evidence store
  */
 export const evidenceKeyval = {
-  async get(key, store) {
-    return (await dbPromise).get(store, key);
+  async get(key) {
+    return (await dbPromise).get(storeKey, key);
   },
-  async set(key, val, store) {
-    return (await dbPromise).put(store, val, key);
+  async set(key, val) {
+    return (await dbPromise).put(storeKey, val, key);
   },
-  async del(key, store) {
-    return (await dbPromise).delete(store, key);
+  async del(key) {
+    return (await dbPromise).delete(storeKey, key);
   },
-  async clear(store) {
-    return (await dbPromise).clear(store);
+  async clear() {
+    return (await dbPromise).clear(storeKey);
   },
-  async keys(store) {
-    return (await dbPromise).getAllKeys(store);
+  async keys() {
+    return (await dbPromise).getAllKeys(storeKey);
   },
 };

--- a/src/background/analysis/requestAnalysis/tagRequests.js
+++ b/src/background/analysis/requestAnalysis/tagRequests.js
@@ -7,30 +7,6 @@ import { getHostname } from '../utility/util.js'
 const parentJson = require('../../../assets/parents.json');
 
 
-/**
- * Tells us whether or not the request was initiated by an origin that the user intended
- * 
- * Defined in tagRequests.js
- * 
- * Used in analyze.js
- * 
- * @param {string} rootU the rootURL of the request
- * @returns {Promse<boolean>} true if first party, false if third party
- */
-async function tagParty(rootU) {
-    /**
-    * Gets the ten most recently visited websites
-    * @var historyQuery Searches most recent sites opened in the browser
-    */
-    var historyQuery = await browser.history.search({text: "", maxResults: 10})
-    const rootUrl = getHostname(rootU);
-    let recentlyVisited = new Set()
-    for (let page of historyQuery) {
-        recentlyVisited.add(getHostname(page.url));
-    }
-    return recentlyVisited.has(rootUrl)
-}
-
 
 /**
 * Identifies if the request url hostname is in our list of parent companies, modified from Disconnect's entities.json,
@@ -62,4 +38,4 @@ function tagParent(reqUrl, parents = parentJson) {
     return null
   }
 
-export { tagParty, tagParent}
+export { tagParent}

--- a/src/exportData/createBlob.js
+++ b/src/exportData/createBlob.js
@@ -3,7 +3,7 @@ Licensed per https://github.com/privacy-tech-lab/privacy-pioneer/blob/main/LICEN
 privacy-tech-lab, https://www.privacytechlab.org/
 */
 
-import { storeEnum, exportTypeEnum } from "../background/analysis/classModels";
+import { exportTypeEnum } from "../background/analysis/classModels";
 import { evidenceKeyval } from "../background/analysis/interactDB/openDB.js";
 import { buildTsvString } from "./createExportString.js";
 
@@ -16,9 +16,8 @@ async function buildEvidenceAsArray(timeStampLB) {
 
     var evidenceArr = []
 
-    // update the arr with the evidences in both stores
-    evidenceArr = await walkStoreAndBuildArr(storeEnum.firstParty, evidenceArr, timeStampLB)
-    evidenceArr = await walkStoreAndBuildArr(storeEnum.thirdParty, evidenceArr, timeStampLB)
+    // update the arr with evidence
+    evidenceArr = await walkStoreAndBuildArr(evidenceArr, timeStampLB)
 
     return evidenceArr
 }
@@ -30,13 +29,13 @@ async function buildEvidenceAsArray(timeStampLB) {
  * @param {Array} evidenceObjectArr The array we are building
  * @returns {Promise<Array<Evidence>>} 
  */
-async function walkStoreAndBuildArr(store, evidenceObjectArr, timeStampLB) {
+async function walkStoreAndBuildArr(evidenceObjectArr, timeStampLB) {
 
-    const allKeys = await evidenceKeyval.keys(store);
+    const allKeys = await evidenceKeyval.keys();
 
     // iterate through all the rootUrls we have in the store
     for (const key of allKeys) {
-        const evidenceDict = await evidenceKeyval.get(key, store);
+        const evidenceDict = await evidenceKeyval.get(key);
         for (const [permLevel, typeLevel] of Object.entries(evidenceDict)) {
             for (const [type, reqUrlLevel] of Object.entries(typeLevel)){
                 for (const [reqUrl, evidenceObject] of Object.entries(reqUrlLevel)){

--- a/src/libs/indexed-db/updateWatchlist.js
+++ b/src/libs/indexed-db/updateWatchlist.js
@@ -7,7 +7,7 @@ import { watchlistKeyval } from "./openDB.js";
 import { evidenceKeyval as evidenceIDB } from "../../background/analysis/interactDB/openDB.js";
 import { watchlistHashGen } from "../../background/analysis/utility/util.js";
 import { getState } from "../../background/analysis/buildUserData/structuredRoutines.js";
-import { keywordTypes, permissionEnum, storeEnum, typeEnum } from "../../background/analysis/classModels.js";
+import { keywordTypes, permissionEnum } from "../../background/analysis/classModels.js";
 
 
 /**
@@ -64,17 +64,15 @@ import { keywordTypes, permissionEnum, storeEnum, typeEnum } from "../../backgro
   * @returns {void} Nothing. Updates and deletes as described.
   */
   const deleteKeyword = async (id) => {
-    let firstEvKeys = await evidenceIDB.keys(storeEnum.firstParty)
-    let thirdEvKeys = await evidenceIDB.keys(storeEnum.thirdParty)
-  
+
+    let evKeys = await evidenceIDB.keys()
     /**
      * Deletes evidence if watchlistHash of the evidence is the same as the id we are deleting from the watchlist
      * @param {Object} evidenceStoreKeys All keys from the related store, taken from the above lines
-     * @param {String} store Store name from storeEnum
      */
-    function runDeletion(evidenceStoreKeys, store) {
+    function runDeletion(evidenceStoreKeys) {
       evidenceStoreKeys.forEach(async (website) => {
-        let a = await evidenceIDB.get(website, store)
+        let a = await evidenceIDB.get(website)
         if (a == undefined) {
           return
         } // shouldn't happen but just in case
@@ -93,13 +91,12 @@ import { keywordTypes, permissionEnum, storeEnum, typeEnum } from "../../backgro
             delete a[perm]
           }
         }
-        await evidenceIDB.set(website, a, store)
+        await evidenceIDB.set(website, a)
       })
     }
   
     // delete from Evidence
-    runDeletion(firstEvKeys, storeEnum.firstParty)
-    runDeletion(thirdEvKeys, storeEnum.thirdParty)
+    runDeletion(evKeys)
   
     // delete from watchlist
     await watchlistKeyval.delete(id)

--- a/src/libs/settings/index.js
+++ b/src/libs/settings/index.js
@@ -7,7 +7,6 @@ import { settingsKeyval, watchlistKeyval } from "../indexed-db/openDB.js"
 import {
   settingsModelsEnum,
   permissionEnum,
-  storeEnum,
 } from "../../background/analysis/classModels"
 import { evidenceKeyval } from "../../background/analysis/interactDB/openDB"
 
@@ -112,8 +111,7 @@ export const getTheme = async () => {
  * delete all evidence
  */
 export const deleteEvidenceDB = async () => {
-  await evidenceKeyval.clear(storeEnum.firstParty)
-  await evidenceKeyval.clear(storeEnum.thirdParty)
+  await evidenceKeyval.clear()
 }
 
 /**

--- a/src/libs/website-badge/index.js
+++ b/src/libs/website-badge/index.js
@@ -5,7 +5,6 @@ privacy-tech-lab, https://www.privacytechlab.org/
 
 import React from "react"
 import styled from "styled-components"
-import { storeEnum } from "../../background/analysis/classModels.js"
 import { getParent, getParents } from "../company-icons/getCompany.js"
 import WebsiteLogo, { CompanyLogo } from "../website-logo"
 
@@ -52,14 +51,6 @@ const WebsiteBadge = ({ website, showParent, party }) => {
         >
           {website}
         </span>
-        {party == storeEnum.thirdParty ? (
-          <SParty
-            data-position="top"
-            data-tip="This site was loaded in with another site you visited"
-          >
-            3rd
-          </SParty>
-        ) : null}
       </span>
       {showParent ? logo : null}
     </SBadge>

--- a/src/options/components/website-label-list/index.js
+++ b/src/options/components/website-label-list/index.js
@@ -7,7 +7,6 @@ import React from "react"
 import WebsiteBadge from "../../../libs/website-badge"
 import LabelCard from "../../../libs/label-card"
 import { SContainer, SItem, SLabel, SLabelGroup, SSeperator } from "./style"
-import { storeEnum } from "../../../background/analysis/classModels"
 
 /**
  * Makes label cards for a given website
@@ -53,11 +52,7 @@ const LabelCards = ({ website, handleTap, allLabels, webLabels }) => {
  * @param webLabels
  */
 const WebsiteLabelList = ({ websites, recent, handleTap, allLabels }) => {
-  const entries = recent
-    ? Object.entries(websites).filter(
-        ([website, data]) => data.party == storeEnum.firstParty
-      )
-    : Object.entries(websites)
+  const entries = Object.entries(websites)
   return (
     <SContainer>
       {entries


### PR DESCRIPTION
## Description
- Abandon 1st/3rd party root distinction. 
- All evidence in one object store. 
- Don't use history query anymore. 
- Get rootUrl with `tabs.get(tabID)` instead of `originUrl` property. 
- Default to `originUrl` property if `tabs.get()` throws an error (-1 value or user closes a window) 

## Impact

These changes make our options page much easier to understand and they speed up the extension!

Close #313 on merge.