### PR TITLE
#328 create evidenceDescription object in classModels.js. Use this ob…

### DIFF
--- a/src/background/analysis/classModels.js
+++ b/src/background/analysis/classModels.js
@@ -106,6 +106,7 @@ export class Evidence {
 
 /**
  * Used for the TSV export to describe evidence object
+ * Should mirror the constructor of the above Evidence class exactly
  */
 export const evidenceDescription = Object.freeze({
   timestamp: {

--- a/src/background/analysis/classModels.js
+++ b/src/background/analysis/classModels.js
@@ -103,6 +103,47 @@ export class Evidence {
   }
 }
 
+
+/**
+ * Used for the TSV export to describe evidence object
+ */
+export const evidenceDescription = Object.freeze({
+  timestamp: {
+    title: "Timestamp"
+  },
+  permission: {
+    title: "Permission"
+  },
+  rootUrl: {
+    title: "Root URL"
+  },
+  snippet: {
+    title: "HTTP Snippet"
+  },
+  requestUrl: {
+    title: "Request URL"
+  },
+  typ: {
+    title: "Type"
+  },
+  index: {
+    title: "Index"
+  },
+  parentCompany: {
+    title: "Parent Company"
+  },
+  watchlistHash: {
+    title: 'Watchlist Hash'
+  },
+  extraDetail: {
+    title: "Extra Detail"
+  },
+  cookie: {
+    title: "Cookie?"
+  }
+})
+
+
 /**
  * @class KeywordObject
  * @property {string|RegExp} keyword A keyword we search for

--- a/src/exportData/createExportString.js
+++ b/src/exportData/createExportString.js
@@ -3,6 +3,8 @@ Licensed per https://github.com/privacy-tech-lab/privacy-pioneer/blob/main/LICEN
 privacy-tech-lab, https://www.privacytechlab.org/
 */
 
+import { evidenceDescription } from "../background/analysis/classModels.js"
+
 /**
  * Converts an array of Evidence Objects into a csv string.
  * Only adds snippets for Evidence with indexes
@@ -36,25 +38,15 @@ privacy-tech-lab, https://www.privacytechlab.org/
      * used to make sure that every column gets populated regardless of the keys
      * of a particular evidence
     */
-    const columnMapping = {
-        0: 'timestamp',
-        1: 'permission',
-        2: 'rootUrl',
-        3: 'snippet',
-        4: 'requestUrl',
-        5: 'typ',
-        6: 'index',
-        7: 'firstPartyRoot',
-        8: 'parentCompany',
-        9: 'watchlistHash',
-        10: 'extraDetail'
-    }
+    const columnMapping = {}
+    const columnTitles = []
 
-    // initiate column titles
-    const columnTitles = [
-        'Timestamp', 'Permission', 'rootUrl', 'httpSnippet', 'reqUrl', 
-        'Type', 'Index', 'FirstParty?', 'Parent', 'Extra Detail'
-    ];
+    var i = 0
+    for ( const [trait, desc] of Object.entries(evidenceDescription) ) {
+        columnMapping[i] = trait
+        columnTitles.push(desc.title)
+        i += 1
+    }
 
     var strArray = [ columnTitles.join('\t') ] //initialze the tsv with the titles.
 
@@ -63,7 +55,7 @@ privacy-tech-lab, https://www.privacytechlab.org/
         var rowArr = []
         for (const [header, value] of Object.entries(evidenceObj) ) {
             // get this object alligned with the columns
-            while (columnIndex < 11 && columnMapping[columnIndex] != header) {
+            while (columnIndex < columnTitles.length && columnMapping[columnIndex] != header) {
                 rowArr.push('')
                 columnIndex += 1
             }


### PR DESCRIPTION
It's unfortunately pretty annoying to get the names of all the traits of a class in JS, so I just went ahead and added an object to describe the traits of Evidence and put this declaration right below the Evidence class so it's clear that it should be changed in tandem.

Close #328 on merge