### PR TITLE
#343 fix bugs surrounding zipcode/state

### DIFF
--- a/src/options/views/watchlist-view/components/edit-modal/components/input-validators.js
+++ b/src/options/views/watchlist-view/components/edit-modal/components/input-validators.js
@@ -6,11 +6,11 @@ privacy-tech-lab, https://www.privacytechlab.org/
 import {
   typeEnum,
   permissionEnum,
-} from "../../../../../../background/analysis/classModels"
+} from "../../../../../../background/analysis/classModels.js"
 import {
   stateObj,
   getState,
-} from "../../../../../../background/analysis/buildUserData/structuredRoutines"
+} from "../../../../../../background/analysis/buildUserData/structuredRoutines.js"
 // allows for input validation of items a user is attempting to add to their watch list
 
 const inputValidator = {
@@ -102,7 +102,8 @@ const validate = ({
       return false
     }
     if (zip != undefined && state != undefined) {
-      if (getState(zip)[0] != state) {
+      const st = getState(zip)
+      if (typeof(st) != "undefined" && st[0] != state) {
         badInput("state / zip combination")
         return false
       }


### PR DESCRIPTION
🐛 squash. 
- Type protection from undefined return from `getState`. 
- Structure city and addresses as arrays of Keyword objects
- Interact with `stateObj` properties correctly by iterating through key values instead of using `obj.var` syntax (which always returns undefined)
- Fix imports