### PR TITLE
fix bug by updating the labels/websites passed in init.js. Move getPe…

### DIFF
--- a/src/libs/init.js
+++ b/src/libs/init.js
@@ -2,6 +2,7 @@ import ReactTooltip from "react-tooltip"
 import { getWebsites, getLabels } from "./indexed-db/getIdbData"
 import exData from "./tour/exData.json"
 import { getTourStatus } from "./indexed-db/settings"
+import { filterLabelObject, getPermMapping } from "../options/views/search-view/components/filter-search/components/filterLabels.js"
 
 /**
  *
@@ -79,11 +80,30 @@ export const searchInit = ({
           })
         })
       } else {
-        setWebsites(location.state.websites)
-        setFilteredWebsites(location.state.websites)
-        setLabels(location.state.labels)
-        setFilteredLabels(location.state.labels)
-      }
+        if (location.state.labeltype === undefined) {
+          setWebsites(location.state.websites)
+          setFilteredWebsites(location.state.websites)
+          setLabels(location.state.labels)
+          setFilteredLabels(location.state.labels)
+        }
+        else {
+          // case where we are passed a filter
+          setWebsites(location.state.websites)
+          setLabels(location.state.labels)
+          const filteredLabels = filterLabelObject( location.state.labels, getPermMapping(location.state.labeltype) )
+
+          // remove websites without labels after filter
+          var filteredWebsites = {}
+          for (const [perm, siteObject] of Object.entries(filteredLabels)) {
+            for (const site of Object.keys(siteObject)){
+              filteredWebsites[site] = location.state.websites[site]
+            }
+          }
+          // set values
+          setFilteredLabels(filteredLabels)
+          setFilteredWebsites(filteredWebsites)
+        }
+      } 
     }
   })
 }

--- a/src/options/views/search-view/components/filter-search/components/filterLabels.js
+++ b/src/options/views/search-view/components/filter-search/components/filterLabels.js
@@ -51,3 +51,21 @@ export const filterLabelObject = (
   }
   return updatedLabels
 }
+
+/**
+* Takes in a type passed from the previous page and returns
+* the appropriate filter mapping
+* @param {string} typ
+* @returns {Dict}
+*/
+
+export const getPermMapping = (typ) => {
+ const mapping = {
+   monetization: false,
+   location: false,
+   watchlist: false,
+   tracking: false,
+ }
+ mapping[typ] = true
+ return mapping
+}

--- a/src/options/views/search-view/components/filter-search/index.js
+++ b/src/options/views/search-view/components/filter-search/index.js
@@ -3,7 +3,8 @@ import SearchBar from "./components/search-bar"
 import React, { useState } from "react"
 import { CompanyLogoSVG } from "../../../../../libs/icons/company-icons"
 import { removeLeadingWhiteSpace } from "../../../../../background/analysis/utility/util"
-import { filterLabelObject } from "./components/filterLabels"
+import { filterLabelObject, getPermMapping } from "./components/filterLabels"
+
 
 /**
  * Combination of filter section and search section
@@ -26,24 +27,6 @@ const FilterSearch = ({
     Object.keys(CompanyLogoSVG).map((company) => {
       mapping[company] = false
     })
-    return mapping
-  }
-
-  /**
-   * Takes in a type passed from the previous page and returns
-   * the appropriate filter mapping
-   * @param {string} typ
-   * @returns {Dict}
-   */
-
-  const getPermMapping = (typ) => {
-    const mapping = {
-      monetization: false,
-      location: false,
-      watchlist: false,
-      tracking: false,
-    }
-    mapping[typ] = true
     return mapping
   }
 


### PR DESCRIPTION
Fixes bug described in #346. Only front-end changes. Filters labels/websites in `init.js` when we are passed a permission filter from previous page (when you click the large labels on the home page).

Close #346 on merge.