### PR TITLE
Rename Watchlist evidence to 'Personal' Category

### DIFF
--- a/src/background/analysis/buildUserData/importSearchData.js
+++ b/src/background/analysis/buildUserData/importSearchData.js
@@ -71,7 +71,7 @@ async function importData() {
   var networkKeywords = {};
   // watchlist == data entered by the user in our extension
   // ex phone numbers, emails, etc
-  networkKeywords[permissionEnum.watchlist] = {};
+  networkKeywords[permissionEnum.personal] = {};
 
   // first let's build up the location info
   var locCoords = await getLocationData();
@@ -142,7 +142,7 @@ async function importData() {
 
   // if we have a phone we put it in the network keywords dict
   if (typeof userPhone !== "undefined") {
-    networkKeywords[permissionEnum.watchlist][typeEnum.phoneNumber] = userPhone;
+    networkKeywords[permissionEnum.personal][typeEnum.phoneNumber] = userPhone;
   }
 
   // build location Elements
@@ -228,9 +228,9 @@ async function importData() {
       encodedEmails[email] = [base64EncodedObj, urlBase64EncodedObj];
     });
 
-    networkKeywords[permissionEnum.watchlist][typeEnum.emailAddress] =
+    networkKeywords[permissionEnum.personal][typeEnum.emailAddress] =
       normalEmails;
-    networkKeywords[permissionEnum.watchlist][typeEnum.encodedEmail] =
+    networkKeywords[permissionEnum.personal][typeEnum.encodedEmail] =
       encodedEmails;
   }
 
@@ -247,7 +247,7 @@ async function importData() {
       );
       regexKeywords.push(wordObj);
     });
-    networkKeywords[permissionEnum.watchlist][typeEnum.userKeyword] =
+    networkKeywords[permissionEnum.personal][typeEnum.userKeyword] =
       regexKeywords;
   }
 
@@ -265,7 +265,7 @@ async function importData() {
       const ipObj = createKeywordObj(ipRegex, typeEnum.ipAddress, origHash);
       ipArr.push(ipObj);
     }
-    networkKeywords[permissionEnum.watchlist][typeEnum.ipAddress] = ipArr;
+    networkKeywords[permissionEnum.personal][typeEnum.ipAddress] = ipArr;
   }
 
   // build tracking info

--- a/src/background/analysis/buildUserData/structureUserData.js
+++ b/src/background/analysis/buildUserData/structureUserData.js
@@ -107,14 +107,14 @@ function hashUserDictValues(networkKeywords) {
   ]); // these get hashed in importData
 
   for (const [t, valArr] of Object.entries(
-    networkKeywords[permissionEnum.watchlist]
+    networkKeywords[permissionEnum.personal]
   )) {
     if (!excludedSet.has(t)) {
       var replacedArr = [];
       for (const keywordItem of valArr) {
         replacedArr.push(createKeywordObj(keywordItem, t));
       }
-      networkKeywords[permissionEnum.watchlist][t] = replacedArr;
+      networkKeywords[permissionEnum.personal][t] = replacedArr;
     }
   }
 

--- a/src/background/analysis/classModels.js
+++ b/src/background/analysis/classModels.js
@@ -201,7 +201,7 @@ export const timeRangeEnum = Object.freeze({
 export const permissionEnum = Object.freeze({
   monetization: "monetization",
   location: "location",
-  watchlist: "watchlist",
+  personal: "personal",
   tracking: "tracking",
 });
 
@@ -223,7 +223,7 @@ export const typeEnum = Object.freeze({
   city: "city",
   region: "region",
 
-  // watchlist types
+  // personal types
   phoneNumber: "phoneNumber",
   emailAddress: "emailAddress",
   encodedEmail: "encodedEmail",
@@ -249,17 +249,6 @@ export const keywordTypes = Object.freeze({
     toolTip:
       "We will flag instances where the entered keyword is shared with a third-party.",
   },
-  location: {
-    displayName: "Street Address",
-    placeholder: {
-      streetAddress: "45 Wyllys Ave",
-      city: "Middletown",
-      region: "Conneticut",
-      zipCode: "06459",
-    },
-    toolTip:
-      "We will flag instances where the entered location data is shared with a third-party.",
-  },
   phoneNumber: {
     displayName: "Phone Number",
     placeholder: "+1 (860) 685-2000",
@@ -271,6 +260,17 @@ export const keywordTypes = Object.freeze({
     placeholder: "jdoe@wesleyan.edu",
     toolTip:
       "We will flag instances where the entered email is shared with a third-party, both in the form you write it and in an alternate representation (The Trade Desk's UID)",
+  },
+  location: {
+    displayName: "Street Address",
+    placeholder: {
+      streetAddress: "45 Wyllys Ave",
+      city: "Middletown",
+      region: "Conneticut",
+      zipCode: "06459",
+    },
+    toolTip:
+      "We will flag instances where the entered location data is shared with a third-party.",
   },
   ipAddress: {
     displayName: "IP Address",
@@ -346,9 +346,9 @@ export const privacyLabels = Object.freeze({
       },
     },
   },
-  watchlist: {
-    displayName: "Watchlist",
-    description: "Web traffic data that contains keywords from your custom watchlist.",
+  personal: {
+    displayName: "Personal",
+    description: "Personal data from your custom watchlist that was found in your web traffic.",
     types: {
       phoneNumber: {
         displayName: "Phone Number",

--- a/src/background/analysis/requestAnalysis/scanCookies.js
+++ b/src/background/analysis/requestAnalysis/scanCookies.js
@@ -78,11 +78,11 @@ function getAllEvidenceForCookies(cookies, rootUrl, reqUrl, userData) {
    * @returns {Void} Nothing. Updates evidenceArr as necessary
    */
   function runWatchlistAnalysis(cookieString) {
-    if (!permissionEnum.watchlist in networkKeywords) {
+    if (!permissionEnum.personal in networkKeywords) {
       return;
     }
 
-    const watchlistDict = networkKeywords[permissionEnum.watchlist];
+    const watchlistDict = networkKeywords[permissionEnum.personal];
 
     if (typeEnum.phoneNumber in watchlistDict) {
       watchlistDict[typeEnum.phoneNumber].forEach((number) => {

--- a/src/background/analysis/requestAnalysis/scanHTTP.js
+++ b/src/background/analysis/requestAnalysis/scanHTTP.js
@@ -104,11 +104,11 @@ function getAllEvidenceForRequest(request, userData) {
    * @returns {Void} Nothing. Updates evidenceArr as necessary
    */
   function runWatchlistAnalysis() {
-    if (!permissionEnum.watchlist in networkKeywords) {
+    if (!permissionEnum.personal in networkKeywords) {
       return;
     }
 
-    const watchlistDict = networkKeywords[permissionEnum.watchlist];
+    const watchlistDict = networkKeywords[permissionEnum.personal];
 
     if (typeEnum.phoneNumber in watchlistDict) {
       watchlistDict[typeEnum.phoneNumber].forEach((number) => {

--- a/src/background/analysis/requestAnalysis/searchFunctions.js
+++ b/src/background/analysis/requestAnalysis/searchFunctions.js
@@ -254,7 +254,7 @@ function regexSearch(
   rootUrl,
   reqUrl,
   type,
-  perm = permissionEnum.watchlist
+  perm = permissionEnum.personal
 ) {
   const keywordIDWatch = keywordObj.keywordHash;
   const keyword = keywordObj.keyword;
@@ -473,7 +473,7 @@ function ipSearch(strReq, ipObj, rootUrl, reqUrl) {
 function encodedEmailSearch(strReq, networkKeywords, rootUrl, reqUrl) {
   var output = [];
   const encodedObj =
-    networkKeywords[permissionEnum.watchlist][typeEnum.encodedEmail];
+    networkKeywords[permissionEnum.personal][typeEnum.encodedEmail];
   const emails = Object.keys(encodedObj);
   emails.forEach((email) => {
     let encodeLst = encodedObj[email];
@@ -486,7 +486,7 @@ function encodedEmailSearch(strReq, networkKeywords, rootUrl, reqUrl) {
       if (output != -1) {
         output.push(
           createEvidenceObj(
-            permissionEnum.watchlist,
+            permissionEnum.personal,
             rootUrl,
             strReq,
             reqUrl,

--- a/src/background/analysis/utility/util.js
+++ b/src/background/analysis/utility/util.js
@@ -142,7 +142,7 @@ const getAllPerms = () => {
     permissionEnum.location,
     permissionEnum.monetization,
     permissionEnum.tracking,
-    permissionEnum.watchlist,
+    permissionEnum.personal,
   ];
 };
 

--- a/src/libs/icons/index.js
+++ b/src/libs/icons/index.js
@@ -451,7 +451,7 @@ export const getLabelIcon = (label, size = "24px") => {
       return <Location size={size} />;
     case "tracking":
       return <Tracking size={size} />;
-    case "watchlist":
+    case "personal":
       return <Personal size={size} />;
     case "monetization":
       return <Money size={size} />;

--- a/src/libs/indexed-db/settings/index.js
+++ b/src/libs/indexed-db/settings/index.js
@@ -26,7 +26,7 @@ export const setDefaultSettings = async () => {
     await settingsKeyval.set(permissionEnum.location, true);
     await settingsKeyval.set(permissionEnum.monetization, true);
     await settingsKeyval.set(permissionEnum.tracking, true);
-    await settingsKeyval.set(permissionEnum.watchlist, true);
+    await settingsKeyval.set(permissionEnum.personal, true);
     const darkTheme = window.matchMedia("(prefers-color-scheme: dark)");
     await settingsKeyval.set(
       "theme",

--- a/src/options/views/home-view/components/label-summary-card/style.js
+++ b/src/options/views/home-view/components/label-summary-card/style.js
@@ -14,7 +14,7 @@ const getColor = (labeltype) => {
       return "linear-gradient(180deg, #B7AFF2 0%, #5C7ADD 100%)";
     case permissionEnum.tracking:
       return "linear-gradient(180deg, #0BD0EA 0%, #0892a5 100%)";
-    case permissionEnum.watchlist:
+    case permissionEnum.personal:
       return "linear-gradient(180deg, #F6D579 0%, #F5CB5C 100%)";
     default:
       return "linear-gradient(180deg, #FE486A 0%, #f2022e 100%)";

--- a/src/options/views/settings-view/components/data-settings/index.js
+++ b/src/options/views/settings-view/components/data-settings/index.js
@@ -181,7 +181,7 @@ export const LabelToggle = () => {
   const [labelStatus, SetLabelStatus] = useState({
     [permissionEnum.location]: true,
     [permissionEnum.monetization]: true,
-    [permissionEnum.watchlist]: true,
+    [permissionEnum.personal]: true,
     [permissionEnum.tracking]: true,
   });
 

--- a/src/options/views/watchlist-view/components/list-item/index.js
+++ b/src/options/views/watchlist-view/components/list-item/index.js
@@ -12,6 +12,7 @@ import {
   SDropdownItem,
   SButtonText,
   SSection,
+  SCategory
 } from "./style";
 import * as Icons from "../../../../../libs/icons";
 import {
@@ -32,7 +33,7 @@ import {
 } from "../../../../../background/analysis/buildUserData/importSearchData";
 
 /**
- * List item displaying keyword and type
+ * List item displaying keyword, type, and category
  * User can edit/delete keyword from vertical options button
  */
 const ListItem = ({
@@ -58,7 +59,17 @@ const ListItem = ({
     document.addEventListener("mousedown", blur);
     return () => document.removeEventListener("mousedown", blur);
   }, []);
-
+  function categorySwitch(type) {
+    console.log(typeof(type))
+    switch(type){
+      case "userKeyword": return 'Personal'
+      case "phoneNumber": return 'Personal'
+      case "emailAddress": return 'Personal'
+      case "location": return 'Location'
+      case "ipAddress": return 'Tracking'
+      default: return '1'
+    }
+  }
   return (
     <SItem>
       {id == IPINFO_IPKEY || id == IPINFO_ADDRESSKEY  ?  (
@@ -67,7 +78,9 @@ const ListItem = ({
             {keyword}
           </SButtonText>
         </SSection>
-      ): <SSection>{keyword}</SSection>}
+      ) : <SSection>{keyword}</SSection>}
+      
+      
       <ReactTooltip
         id="sButton"
         tipPointerPosition="start"
@@ -80,22 +93,15 @@ const ListItem = ({
       >
         This keyword was automatically generated via ipinfo.io
       </ReactTooltip>
-
-      <ReactTooltip
-        id="sNotification"
-        tipPointerPosition="start"
-        place="left"
-        backgroundColor="var(--primaryBrandColor)"
-        textColor="var(--primaryBrandTintColor)"
-        effect="solid"
-        delayShow="350"
-      >
-        Click this to toggle alerts for this keyword!
-      </ReactTooltip>
-      <div>
         <SType>
           {type in keywordTypes ? keywordTypes[type]["displayName"] : "Error"}
-        </SType>
+      </SType>
+      <SCategory>
+          {categorySwitch(type)}
+        </SCategory>
+      <div>
+        
+        
         <div>
           <SAction
             ref={dropdownRef}

--- a/src/options/views/watchlist-view/components/list-item/style.js
+++ b/src/options/views/watchlist-view/components/list-item/style.js
@@ -12,14 +12,13 @@ export const SItem = styled.div`
   flex-direction: row;
   > * {
     :first-child {
-      width: 50%;
+      flex:2
     }
   }
   > * {
     :last-child {
       display: flex;
       justify-content: space-between;
-      flex-grow: 1;
     }
   }
 `;
@@ -33,9 +32,16 @@ export const SButtonText = styled.text`
   display: flex;
 `;
 
-export const SKeyword = styled.div``;
+export const SKeyword = styled.div`
 
-export const SType = styled.div``;
+`;
+
+export const SType = styled.div`
+flex:1`;
+
+export const SCategory = styled.div`
+flex:1
+`;
 
 export const SAction = styled.div`
   cursor: pointer;

--- a/src/options/views/watchlist-view/index.js
+++ b/src/options/views/watchlist-view/index.js
@@ -147,9 +147,10 @@ const WatchlistView = () => {
               </SAddButton>
             </div>
           </SHeader>
-          <SListHeader>
-            <div>KEYWORD</div>
-            <div>TYPE</div>
+          <SListHeader> 
+            <div style={{flex:2}}>KEYWORD</div> 
+            <div style={{flex:1}}>TYPE</div> 
+            <div style={{flex:1}}>CATEGORY</div>
           </SListHeader>
           <SListContent>
             {items.length != 0 ? (

--- a/src/options/views/watchlist-view/style.js
+++ b/src/options/views/watchlist-view/style.js
@@ -69,15 +69,7 @@ export const SListHeader = styled.div`
   color: var(--secondaryTextColor);
   font-size: var(--body2);
   border-bottom: 1px solid var(--seperatorColor);
-  > * {
-    :first-child {
-      width: 50%;
-    }
-  }
-  > * {
-    :last-child {
-    }
-  }
+  padding-right: 48px
 `;
 
 export const SListContent = styled.div`

--- a/src/tests/mock-data/analysisData.json
+++ b/src/tests/mock-data/analysisData.json
@@ -66,13 +66,13 @@
                 "fingerprintID"
               ]
         },
-        "watchlist" : {
+        "personal" : {
             "ipAddress" : [{"keyword" : "/12345678910/", "keywordHash" : "123456789"}]
         }
 
     },
     "general" : {
-        "watchlist" :{
+        "personal" :{
             "general" : [{"keyword" : "/myname/"}]
         }
     }

--- a/src/tests/mock-data/mockData.json
+++ b/src/tests/mock-data/mockData.json
@@ -44,7 +44,7 @@
         "site7.com": {
             "labels": [
                 "tracking",
-                "watchlist"
+                "personal"
             ],
             "party": "firstPartyEvidence"
         }

--- a/src/tests/mock-data/mockEvidence.json
+++ b/src/tests/mock-data/mockEvidence.json
@@ -52,7 +52,7 @@
                     "city": [{"keyword" : "testCity", "keywordHash" : "222222222"}],
                     "streetAddress": [{"keyword": "1 Test Road", "keywordHash" : "222222222"}]
                 },
-                "watchlist" : {"keyword": "/1234567890/", "keywordHash": "1111111111"}
+                "personal" : {"keyword": "/1234567890/", "keywordHash": "1111111111"}
             },
             {},
             false,

--- a/src/tests/search-view/filterPerms.test.js
+++ b/src/tests/search-view/filterPerms.test.js
@@ -26,8 +26,8 @@ test("Filter By Tracking Only",  () => {
 });
 
 test("Filter By Watchlist Only", () => {
-    const permFilterLabels = getPermMapping('watchlist')
+    const permFilterLabels = getPermMapping('personal')
     const filteredWebsites = filter('', mockEvidence.labelArrayPerSite, permFilterLabels)
-    expect(getPlaceholder(false, {}, permFilterLabels)).toBe('in: watchlist ')
+    expect(getPlaceholder(false, {}, permFilterLabels)).toBe('in: personal ')
     expect(Object.entries(filteredWebsites).length=== 1).toBeTruthy();
 });

--- a/src/tests/userData-functionality/userData.test.js
+++ b/src/tests/userData-functionality/userData.test.js
@@ -15,7 +15,7 @@ import analysisData from "../mock-data/analysisData.json";
   test("test hashUserDictValues", async () => {
     const keywords = analysisData.networkKeywords
     expect(hashUserDictValues(keywords)).toBe(keywords)
-    expect(hashUserDictValues(keywords).watchlist.ipAddress).toBeDefined()
+    expect(hashUserDictValues(keywords).personal.ipAddress).toBeDefined()
     expect(hashUserDictValues(keywords).tracking).toBeDefined()
     expect(hashUserDictValues(keywords).tracking.fingerprinting).toBeDefined()
     expect(hashUserDictValues(keywords).tracking.trackingPixel).toBeDefined()
@@ -25,7 +25,7 @@ import analysisData from "../mock-data/analysisData.json";
 
   test("test general hashUserDictValues", async () => {
     const general = analysisData.general
-    expect(hashUserDictValues(general).watchlist.general[0].keywordHash).toBeTruthy()
+    expect(hashUserDictValues(general).personal.general[0].keywordHash).toBeTruthy()
   });
 
   test("test createKeywordObj", async () => {


### PR DESCRIPTION
As discussed in #484 changes were made to rename mentions of "watchlist" evidence type to "personal" type.  A categrory column was also added to the watchlist page. 

(Most of the work was done by @JustinCasler but I had to recommit changes due to merge conflicts)