### PR TITLE
Empty watchlist fixes

### DIFF
--- a/src/background/analysis/buildUserData/importSearchData.js
+++ b/src/background/analysis/buildUserData/importSearchData.js
@@ -121,7 +121,7 @@ export async function importData() {
     } else {
       for (let [t, val] of Object.entries(keywordObject)) {
         if (t == "keyword") {
-          //If the useres watchlist is not current, then update it
+          //If the user's watchlist is not current, then update it
           if (val != retJson.ip) {
             await saveKeyword(retJson.ip, typeEnum.ipAddress, "ip", true);
             await saveKeyword(locKey, permissionEnum.location, "loc", true);
@@ -173,7 +173,9 @@ export async function importData() {
         keyword: zipRegex,
         keywordHash: locHash,
       });
-      userZipArr.push(zipObj);
+      if (zip[0] != "") {
+        userZipArr.push(zipObj);
+      }
     });
 
     locElems[typeEnum.zipCode] = userZipArr;
@@ -184,7 +186,7 @@ export async function importData() {
     locElems[typeEnum.region] = [];
     const userRegion = user_store_dict[typeEnum.region];
     userRegion.forEach((region) => {
-      if (!locElems[typeEnum.region].includes(region[0])) {
+      if (!locElems[typeEnum.region].includes(region[0]) && region[0] != "") {
         var regex = getRegion(region[0]);
         locElems[typeEnum.region].push(
           new KeywordObject({ keyword: regex, keywordHash: region[1] })
@@ -192,6 +194,8 @@ export async function importData() {
       }
     });
   }
+
+  // NOTE: not inputting a zip code seems to create a similar problem (many unintended false positives)
 
   if (typeEnum.city in user_store_dict) {
     var cityArr = [];

--- a/src/background/analysis/buildUserData/importSearchData.js
+++ b/src/background/analysis/buildUserData/importSearchData.js
@@ -195,8 +195,6 @@ export async function importData() {
     });
   }
 
-  // NOTE: not inputting a zip code seems to create a similar problem (many unintended false positives)
-
   if (typeEnum.city in user_store_dict) {
     var cityArr = [];
     const userCity = user_store_dict[typeEnum.city];

--- a/src/options/views/watchlist-view/components/edit-modal/index.js
+++ b/src/options/views/watchlist-view/components/edit-modal/index.js
@@ -48,9 +48,15 @@ import { requestNotificationPermission } from "../../../../../libs/indexed-db/no
  * @param {string} obj.id
  * @param {function():void} obj.updateList
  */
-export const EditModal = ({ passKeywordType, passKeyword, edit, id, updateList }) => {
+export const EditModal = ({
+  passKeywordType,
+  passKeyword,
+  edit,
+  id,
+  updateList,
+}) => {
   const dropdownRef = useRef();
-  const [showDropdown, setDropdown] = useState(false); 
+  const [showDropdown, setDropdown] = useState(false);
   const [keywordType, setKeywordType] = useState(
     edit ? passKeywordType : "Select Type"
   );
@@ -201,13 +207,28 @@ export const EditModal = ({ passKeywordType, passKeyword, edit, id, updateList }
             <SAction
               onClick={async () => {
                 let key;
+                let displayValue;
+                // Some cases to fix the formatting if the user decides to only input certain parts of a street address to the watchlist
+                if (address == "") {
+                  if (region == "") {
+                    if (zip == "") {
+                      displayValue = `${city}`;
+                    } else {
+                      displayValue = `${city}, ${zip}`;
+                    }
+                  } else {
+                    displayValue = `${region}, ${city} ${zip}`;
+                  }
+                } else {
+                  displayValue = `${address}, ${city}, ${region} ${zip}`;
+                }
                 if (keywordType == permissionEnum.location) {
                   key = {
-                    [typeEnum.streetAddress]: (address == "" ? null : address),
+                    [typeEnum.streetAddress]: address == "" ? null : address,
                     [typeEnum.zipCode]: zip,
                     [typeEnum.region]: region,
                     [typeEnum.city]: city,
-                    display: (address != "") ? `${address}, ${city}, ${region} ${zip}` : ` ${city}, ${region} ${zip}`,
+                    display: displayValue,
                   };
                 } else {
                   key = keyword;


### PR DESCRIPTION
While I was poking around with testing our web crawler, I discovered a bug where, if a user decided to input a Street Address to their watchlist that didn't include a region or zip code (i.e., they only input the city, which is the bare minimum for an entry), then the extension would get flooded with false-positive results, like so:

<img src="https://github.com/privacy-tech-lab/privacy-pioneer/assets/144378508/2a6cd19a-dda2-4a9c-b329-2731a7dae487" width=33% height=33%>

Thankfully, I just had to make sure that empty regions and zip codes weren't being added to the list of keywords to look out for. I've also included some fixes for how the watchlist is displayed when only a city is the input to the Street Address. @atlasharry, I think this is a good chance for you to take a first look at the extension code. I've done a fair amount of testing on these changes and I'm fairly confident they'll work, but I'd like for someone else to check just in case.


