### PR TITLE
579 update packagejson to solve dependabot alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Here is how you install Privacy Pioneer for development purposes:
    xcode-select --install
    ```
 
+   After you build the Privacy Pioneer App using the `npm install -production=false` or `xcode-select --install`, you might find that your package-lock.json file has been updated with dependencies that are different from the ones in the repository. This is because the package-lock.json file is generated based on the versions of the dependencies that are newer available at the time of installation. If you could successfully build the Privacy Pioneer App and run this extension in the brower, you can ignore this issue.
+
    For any issues with incorrect dependency versions, copy the package-lock.json file from the repository into your local directory and run:
 
    ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "style-loader": "^2.0.0",
         "terser-webpack-plugin": "^5.1.1",
         "wait-on": "^7.2.0",
-        "web-ext": "^7.10.0",
+        "web-ext": "^8.2.0",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.5.0",
         "webpack-dev-server": "^4.11.1"
@@ -14866,7 +14866,7 @@
         "tmp": "0.2.1",
         "update-notifier": "6.0.2",
         "watchpack": "2.4.0",
-        "ws": "8.13.0",
+        "ws": "8.17.1",
         "yargs": "17.7.1",
         "zip-dir": "2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -84,10 +84,13 @@
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^5.1.1",
     "wait-on": "^7.2.0",
-    "web-ext": "^7.10.0",
+    "web-ext": "^8.2.0",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^4.11.1"
+  },
+  "resolutions": {
+    "ws": "^8.17.1"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
As discussed in [issue #579](https://github.com/privacy-tech-lab/privacy-pioneer/issues/579), I have updated the `package.json` to avoid the [Dependabot alert 70](https://github.com/privacy-tech-lab/privacy-pioneer/security/dependabot/70). I also updated the readme to explain the discrepancy between the `package.json.lock` file the user build and the one we provided.